### PR TITLE
RK-8545 - update to python node variant images

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,8 +19,7 @@ jobs:
       - run:
           name: Install Serverless CLI and dependencies
           command: |
-            sudo npm i -g serverless
-            sudo apt-get install python-dev -qy            
+            sudo npm i -g serverless            
             sudo pip install -r requirements.txt -t .
 
   deploy-staging:
@@ -33,8 +32,7 @@ jobs:
       - run:
           name: Install Serverless CLI and dependencies
           command: |
-            sudo npm i -g serverless
-            sudo apt-get install python-dev -qy            
+            sudo npm i -g serverless            
             sudo pip install -r requirements.txt -t .
       - run:
           name: Deploy application to staging
@@ -60,8 +58,7 @@ jobs:
       - run:
           name: Install Serverless CLI and dependencies
           command: |
-            sudo npm i -g serverless
-            sudo apt-get install python-dev -qy            
+            sudo npm i -g serverless            
             sudo pip install -r requirements.txt -t .
 
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,8 +19,8 @@ jobs:
       - run:
           name: Install Serverless CLI and dependencies
           command: |
-            sudo npm i -g serverless            
-            sudo pip install -r requirements.txt -t .
+            npm i -g serverless            
+            pip install -r requirements.txt -t .
 
   deploy-staging:
     docker:
@@ -32,8 +32,8 @@ jobs:
       - run:
           name: Install Serverless CLI and dependencies
           command: |
-            sudo npm i -g serverless            
-            sudo pip install -r requirements.txt -t .
+            npm i -g serverless            
+            pip install -r requirements.txt -t .
       - run:
           name: Deploy application to staging
           command: sls deploy --stage staging --token ${STAGING_DEMO_ROOKOUT_TOKEN} --agenthost wss://staging.control.rookout.com
@@ -58,8 +58,8 @@ jobs:
       - run:
           name: Install Serverless CLI and dependencies
           command: |
-            sudo npm i -g serverless            
-            sudo pip install -r requirements.txt -t .
+            npm i -g serverless            
+            pip install -r requirements.txt -t .
 
       - run:
           name: Deploy application to production

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,7 +19,7 @@ jobs:
       - run:
           name: Install Serverless CLI and dependencies
           command: |
-            npm i -g serverless            
+            sudo npm i -g serverless            
             pip install -r requirements.txt -t .
 
   deploy-staging:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,7 +11,7 @@ references:
 jobs:
   build:
     docker:
-      - image: circleci/node:12.10
+      - image: cimg/python:3.8-node
     working_directory: ~/repo
     steps:
       - checkout
@@ -27,7 +27,7 @@ jobs:
 
   deploy-staging:
     docker:
-      - image: circleci/node:12.10
+      - image: cimg/python:3.8-node
     working_directory: ~/repo
     steps:
       - checkout
@@ -46,7 +46,7 @@ jobs:
 
   notify_slack_staging:
     docker:
-        - image: python:3.8
+        - image: cimg/python:3.8-node
     working_directory: ~/repo
     environment:
       ENV: staging
@@ -56,7 +56,7 @@ jobs:
 
   deploy-production:
     docker:
-      - image: circleci/node:12.10
+      - image: cimg/python:3.8-node
     working_directory: ~/repo
     steps:
       - checkout
@@ -76,7 +76,7 @@ jobs:
 
   notify_slack_production:
     docker:
-        - image: python:3.8
+        - image: cimg/python:3.8-node
     working_directory: ~/repo
     environment:
       ENV: production

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -32,7 +32,7 @@ jobs:
       - run:
           name: Install Serverless CLI and dependencies
           command: |
-            npm i -g serverless            
+            sudo npm i -g serverless            
             pip install -r requirements.txt -t .
       - run:
           name: Deploy application to staging
@@ -58,7 +58,7 @@ jobs:
       - run:
           name: Install Serverless CLI and dependencies
           command: |
-            npm i -g serverless            
+            sudo npm i -g serverless            
             pip install -r requirements.txt -t .
 
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,9 +20,7 @@ jobs:
           name: Install Serverless CLI and dependencies
           command: |
             sudo npm i -g serverless
-            sudo apt-get install python-dev -qy
-            sudo curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py
-            sudo python get-pip.py
+            sudo apt-get install python-dev -qy            
             sudo pip install -r requirements.txt -t .
 
   deploy-staging:
@@ -36,9 +34,7 @@ jobs:
           name: Install Serverless CLI and dependencies
           command: |
             sudo npm i -g serverless
-            sudo apt-get install python-dev -qy
-            sudo curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py
-            sudo python get-pip.py
+            sudo apt-get install python-dev -qy            
             sudo pip install -r requirements.txt -t .
       - run:
           name: Deploy application to staging
@@ -65,9 +61,7 @@ jobs:
           name: Install Serverless CLI and dependencies
           command: |
             sudo npm i -g serverless
-            sudo apt-get install python-dev -qy
-            sudo curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py
-            sudo python get-pip.py
+            sudo apt-get install python-dev -qy            
             sudo pip install -r requirements.txt -t .
 
       - run:


### PR DESCRIPTION
circleci deployment isn't working due to python2 eol.
So moving to python3 images with node variant.
Failure here:
https://app.circleci.com/pipelines/github/Rookout/lambda-python-task-generator/146/workflows/ff26d9ff-6732-4bba-bf39-c6e9e624eb7a/jobs/353
info about python with node variant images in circleci:
https://github.com/CircleCI-Public/cimg-python#nodejs